### PR TITLE
Shift photos

### DIFF
--- a/js/team.js
+++ b/js/team.js
@@ -167,7 +167,7 @@ jQuery(function($){
             },
             {
                 "name": "Joyce Luo",
-                "program": "",
+                "program": "Biology & Psychology",
                 "description": "<p>怀着改变世界的英雄梦，祈求安稳的平凡人生</p>",
                 "department": "pr",
                 "social": {

--- a/js/team.js
+++ b/js/team.js
@@ -229,7 +229,8 @@ jQuery(function($){
                 "department": "pr",
                 "social": {
                     "wechat": "x_1970-2000",
-                }
+                },
+                "style": `object-position: bottom;`
             },
             {
                 "name": "Yichen Wang",
@@ -252,7 +253,7 @@ jQuery(function($){
 
         ],
         "html": "",
-        "template": "<div class=\"col-lg-3 col-md-3 col-sm-4\" data-department=\"%s\"> <div class=\"single_team wow fadeInUp\"> <div class=\"team_img\"> <img src=\"img/team/%s.jpg\" onerror=\"this.src='img/team/placeholder-user-photo.png';\"> </div> <h5>%s</h5> <span>%s</span> <div class=\"description\">%s</div> <div class=\"team_social\">%s</div> </div> </div>",
+        "template": "<div class=\"col-lg-3 col-md-3 col-sm-4\" data-department=\"%s\"> <div class=\"single_team wow fadeInUp\"> <div class=\"team_img\"> <img src=\"img/team/%s.jpg\" style=\"%s\"  onerror=\"this.src='img/team/placeholder-user-photo.png';\"> </div> <h5>%s</h5> <span>%s</span> <div class=\"description\">%s</div> <div class=\"team_social\">%s</div> </div> </div>",
         "social": "<a href=\"%s\" target=\"blank\"><i class=\"fa fa-%s\"></i></a>",
         "wechat": "<a class=\"wechat-button\" data-toggle=\"tooltip\" title=\"复制粘贴 ID: %s 到微信加入好友\" data-trigger=\"click focus\"><i class=\"fa fa-wechat\"></i></a>",
         "prepare": function () {
@@ -269,6 +270,7 @@ jQuery(function($){
                 self.html += sprintf(self.template,
                     member["department"],
                     member["name"].replace(/ /g,'').toLowerCase(),
+                    member["style"] ? member["style"]: "",
                     member["name"],
                     member["program"],
                     member["description"],

--- a/style.css
+++ b/style.css
@@ -1040,6 +1040,7 @@ div[data-dimension] {
   margin: 0 auto 15px;
   width: 150px;
   object-fit: cover;
+  object-position: top;
 }
 .single_team h5 {
   color: #555;


### PR DESCRIPTION
- Shifted images up as some member's photos were cut off
- Allow hardcoded inline styling for images, this way we can manually style images depending on its size and position